### PR TITLE
Fix/remove-curl-output-dir

### DIFF
--- a/src/install-hpcflow-flags.sh
+++ b/src/install-hpcflow-flags.sh
@@ -311,7 +311,7 @@ download_artifact_to_temp() {
 
 	echo $progress_string_1
 	echo
-	curl -s --o "${TEMPD}/${artifact_name} $download_link -O -L
+	curl -s --o "${TEMPD}/${artifact_name}" $download_link -O -L
 	echo $progress_string_2
 	echo
 

--- a/src/install-hpcflow-flags.sh
+++ b/src/install-hpcflow-flags.sh
@@ -311,7 +311,7 @@ download_artifact_to_temp() {
 
 	echo $progress_string_1
 	echo
-	curl -s --output-dir $TEMPD $download_link -O -L
+	curl -s --o "${TEMPD}/${artifact_name} $download_link -O -L
 	echo $progress_string_2
 	echo
 


### PR DESCRIPTION
This replaces the `curl --output-dir $TEMPD` option with `curl --o $TEMPD/$artifact_name` since the version of curl packaged with CentOS on CSF3 is sufficiently old not to support the `--output-dir` option.

Close #20 